### PR TITLE
Remove unnecessary parseFloat in mxAbstractCanvas2D.format

### DIFF
--- a/javascript/src/js/util/mxAbstractCanvas2D.js
+++ b/javascript/src/js/util/mxAbstractCanvas2D.js
@@ -180,7 +180,7 @@ mxAbstractCanvas2D.prototype.createState = function()
  */
 mxAbstractCanvas2D.prototype.format = function(value)
 {
-	return Math.round(parseFloat(value));
+	return Math.round(value);
 };
 
 /**


### PR DESCRIPTION
The format() is only ever used with numbers. While parseFloat for a number returns the very same number, it's wholly unnecessary.

Discovered this mistake while porting mxGraph to TS.