### PR TITLE
added isEdgeIgnored functionality on hierarchical models

### DIFF
--- a/javascript/src/js/layout/hierarchical/mxHierarchicalLayout.js
+++ b/javascript/src/js/layout/hierarchical/mxHierarchicalLayout.js
@@ -418,7 +418,9 @@ mxHierarchicalLayout.prototype.getEdges = function(cell)
 						((target == cell && (this.parent == null || this.isAncestor(this.parent, source, this.traverseAncestors))) ||
 						 	(source == cell && (this.parent == null || this.isAncestor(this.parent, target, this.traverseAncestors))))))
 		{
-			result.push(edges[i]);
+			if (!this.isEdgeIgnored(edges[i])) {
+				result.push(edges[i]);
+			}
 		}
 	}
 


### PR DESCRIPTION
Hi,

First of all, excuse me if this repository is not the correct one to submit a PR. (I understood MXgraph is for questions... and this one is the develop-related issues and PRs).

Deeping with the issue https://github.com/jgraph/mxgraph/issues/422 , I have found that not every layout with the ignoreEdges functionality.
A quick search says that only tree, circle, parallelEdge, and the base graphLayout take this restriction into account.

Making hot-changes in my chrome-browser, I have found that to enable this feature in hierarchy models (which is something I need), it is necessary to add `if (!this.isEdgeIgnored(edges[i]))` right before `result.push(edges[i]);` on method `mxHierarchicalLayout.prototype.getEdges` on file `mxHierarchicalLayout.js`.

I made that change it seems to work on google chrome.