### PR TITLE
Added property layoutIgnore

### DIFF
--- a/javascript/src/js/layout/mxGraphLayout.js
+++ b/javascript/src/js/layout/mxGraphLayout.js
@@ -256,9 +256,9 @@ mxGraphLayout.prototype.isVertexIgnored = function(vertex)
 mxGraphLayout.prototype.isEdgeIgnored = function(edge)
 {
 	var model = this.graph.getModel();
-	
 	return !model.isEdge(edge) ||
 		!this.graph.isCellVisible(edge) ||
+		model.isLayoutIgnored(edge) ||
 		model.getTerminal(edge, true) == null ||
 		model.getTerminal(edge, false) == null;
 };

--- a/javascript/src/js/model/mxCell.js
+++ b/javascript/src/js/model/mxCell.js
@@ -370,6 +370,18 @@ mxCell.prototype.isVisible = function()
 };
 
 /**
+ * Function: isLayoutIgnored
+ *
+ * Returns true if the cell is marked to be ignored by layout algorithmics.
+ */
+mxCell.prototype.isLayoutIgnored = function () {
+	if (this.value && this.value.hasAttribute('layoutIgnore')) {
+		return this.value.getAttribute('layoutIgnore') != 0;
+	}
+	return false;
+};
+
+/**
  * Function: setVisible
  *
  * Specifies if the cell is visible.

--- a/javascript/src/js/model/mxGraphModel.js
+++ b/javascript/src/js/model/mxGraphModel.js
@@ -1813,6 +1813,20 @@ mxGraphModel.prototype.isVisible = function(cell)
 };
 
 /**
+ * Function: isLayoutIgnored
+ * 
+ * Returns true if the given <mxCell> should be ignored by layout algorithmics.
+ * 
+ * Parameters:
+ * 
+ * cell - <mxCell> whose ignored state should be returned.
+ */
+mxGraphModel.prototype.isLayoutIgnored = function(cell)
+{
+	return (cell != null) ? cell.isLayoutIgnored() : false;
+};
+
+/**
  * Function: setVisible
  * 
  * Sets the visible state of the given <mxCell> using <mxVisibleChange> and


### PR DESCRIPTION
Hello,

I have added a new property called layoutIgnore.
First of all, forgive me if I did not fit this new property with the appropriate code-style. If I didn't, please, comment on how should it be and I will change it ASAP.

This change allows marking some edges (or cells) to be ignored by layout algorithmics.
This feature is necessary to generate appropriate diagrams where some nodes should be at the same level.

As an example:
HORIZONTAL FLOW without ignoring flag:
![Captura de pantalla de 2020-01-14 10-53-29](https://user-images.githubusercontent.com/8069372/72333478-24f4dc80-36bc-11ea-9036-195b6da0827a.png)

HORIZONTAL FLOW with ignoring flag:
![Captura de pantalla de 2020-01-14 10-53-04](https://user-images.githubusercontent.com/8069372/72333483-27573680-36bc-11ea-8da1-a645c58dd7c9.png)

This PR is related to PR https://github.com/jgraph/mxgraph2/pull/12 and the issue https://github.com/jgraph/mxgraph/issues/422

Thank you for considering this PR.