### PR TITLE
Makes the mxEdgeHandler consistent with mxConnectionHandler

### DIFF
--- a/javascript/src/js/handler/mxConnectionHandler.js
+++ b/javascript/src/js/handler/mxConnectionHandler.js
@@ -1176,7 +1176,7 @@ mxConnectionHandler.prototype.updateCurrentState = function(me, point)
 /**
  * Function: isCellEnabled
  * 
- * Returns true if the given cell does not allow new connections to be created.
+ * Returns false if the given cell does not allow new connections to be created.
  */
 mxConnectionHandler.prototype.isCellEnabled = function(cell)
 {

--- a/javascript/src/js/handler/mxEdgeHandler.js
+++ b/javascript/src/js/handler/mxEdgeHandler.js
@@ -1147,7 +1147,7 @@ mxEdgeHandler.prototype.getPreviewTerminalState = function(me)
 		this.marker.process(me);
 		var state = this.marker.getValidState();
 		
-		if (state != null && this.graph.isCellLocked(state.cell))
+		if (state != null && !this.isCellEnabled(state.cell))
 		{
 			this.marker.reset();
 		}
@@ -1487,7 +1487,7 @@ mxEdgeHandler.prototype.mouseMove = function(sender, me)
 				}
 			}
 			
-			if (terminalState != null && this.graph.isCellLocked(terminalState.cell))
+			if (terminalState != null && !this.isCellEnabled(terminalState.cell))
 			{
 				terminalState = null;
 				this.marker.reset();
@@ -2449,4 +2449,14 @@ mxEdgeHandler.prototype.destroy = function()
 	this.bends = null;
 	
 	this.removeHint();
+};
+
+/**
+ * Function: isCellEnabled
+ * 
+ * Returns false if the given cell does not allow new connections to be created.
+ */
+mxEdgeHandler.prototype.isCellEnabled = function(cell)
+{
+	return true;
 };


### PR DESCRIPTION
A fix for [jgraph/mxgraph issue #425](https://github.com/jgraph/mxgraph/issues/425)

Applied similar logic to 4262b9b50; created an 'isCellEnabled' method that is used to determine if a cell is enabled for purposes of the preview state 