### PR TITLE
Correcting typos in grapheditor.css

### DIFF
--- a/javascript/examples/grapheditor/www/styles/grapheditor.css
+++ b/javascript/examples/grapheditor/www/styles/grapheditor.css
@@ -384,7 +384,7 @@ div.mxWindow .geButton {
 	padding:6px;
 	margin:6px;
 	color:#a0a0a0;
-	fontSize:13px;
+	font-size:13px;
 }
 .geTitle img {
 	opacity:0.5;
@@ -547,7 +547,7 @@ div.mxWindow .geButton {
 	white-space: nowrap;
 	border-radius:3px;
 	background-color:#0052cc;
-	currsor:pointer;
+	cursor:pointer;
 	transition: background-color 0.1s ease-out;
 	overflow:hidden;
 	text-overflow: ellipsis;


### PR DESCRIPTION
Minor typo corrections in grapheditor.css.  First typo appears to be using the DOM variable name "fontSize" instead of the CSS property name "font-size".  Second typo is a mistyping of CSS property name "cursor".